### PR TITLE
ARGO-1641 Push server initialisation should load all active push subs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Ams Push Server
-The ams push server is a component that handles the push functionality for the respective 
+The ams push server is a component that handles the push functionality for the respective
 push enabled subscriptions in the [argo-messaging-service.](https://github.com/ARGOeu/argo-messaging-service)
 
 ## Perquisites
@@ -49,7 +49,7 @@ Before you start, you need to issue a valid certificate.
       `go test $(go list ./... | grep -v /vendor/)`
 
  ## Configuration
-    
+
  The service depends on a configuration file in order to be able to run.This file contains the following information:
 
  ```json
@@ -63,19 +63,49 @@ Before you start, you need to issue a valid certificate.
   "ams_port": 8080,
   "verify_ssl": true,
   "tls_enabled": true,
-  "trust_unknown_cas": false 
+  "trust_unknown_cas": false,
+  "log_level": "INFO",
+  "skip_subs_load": false
 }
  ```
+ - `service_port:` The port that the service will bind to.  
+ 
+ - `certificate:` The certificate file which the service will use.
+ 
+ - `certificate_key:` The key to the respective certificate
+ 
+ - `certificate_authroties_dir:` Directory containing `.pem` files that the service will use in order to build the trusted CA pool.
+ The CA pool will be used to validate the certificates from incoming client requests.
+ 
+ - `ams_token:` THe argo messaging token that the service will use in order to communicate with ams.`NOTE` that the
+ token `MUST` correspond to a push worker user in ams.
+ 
+ - `ams_host:` The ams http endpoint.
+ 
+ - `ams_port:` The ams http endpoint port.
+ 
+ - `verify_ssl:` Whether or not it should verify the various `https` endpoint it targets.
+ 
+ - `tls_enabled:` Enable or disable tls support between client and server
+ 
+ - `trust_unknown_cas:` Whether or not the service should accept certificates from CAs not found in its trusted CA pool.
+ (Mainly used for development purposes)
+ 
+ - `log_level:` DEBUG,INFO,WARNING,ERROR
+ 
+ - `skip_subs_load:`  The service will try by default to contact the ams in order to retrieve all active push subscriptions   
+ that are assigned to it and start their push cycles`(consume->send->ack)`. This will be done through the its user profile in ams(which is the profile associated with the)
+ `ams_token`). You can control this behavior and decide whether or not to pre-load any already active subscriptions.
+  
 You can find the configuration template at `conf/ams-push-server-config.template`.
 ## Managing the protocol buffers and gRPC definitions
 
 In order to modify any `.proto` file you will need the following
 
  - Read on how to install the protoc compiler on your platform [here.](https://github.com/protocolbuffers/protobuf)
- 
- -  Install the go plugin. `go get -u github.com/golang/protobuf/protoc-gen-go`
- 
- - install the go gRPC package. `go get -u google.golang.org/grpc`
- 
- - Inside `api/<version>/grpc` compile. `protoc -I proto/ proto/ams.proto --go_out=plugins=grpc:proto`
 
+ -  Install the go plugin. `go get -u github.com/golang/protobuf/protoc-gen-go`
+
+ - install the go gRPC package. `go get -u google.golang.org/grpc`
+
+ - Inside `api/<version>/grpc` compile. `protoc -I proto/ proto/ams.proto --go_out=plugins=grpc:proto`

--- a/conf/ams-push-server-config.template
+++ b/conf/ams-push-server-config.template
@@ -9,5 +9,6 @@
   "verify_ssl": true,
   "tls_enabled": true,
   "trust_unknown_cas": false,
-  "log_level": "INFO"
+  "log_level": "INFO",
+  "skip_subs_load": false
 }

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	TrustUnknownCAs bool `json:"trust_unknown_cas"`
 	// log level(DEBUG,INFO,WARNING,ERROR)
 	LogLevel string `json:"log_level" required:"true"`
+	// whether or not it should try to load any push enabled subscriptions, upon starting up
+	SkipSubsLoad bool `json:"skip_subs_load"`
 	// tls configuration to be used by the grpc server
 	tlsConfig *tls.Config
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func (suite *ConfigTestSuite) TestValidateRequired() {
 		TLSEnabled:                true,
 		TrustUnknownCAs:           false,
 		LogLevel:                  "INFO",
+		SkipSubsLoad:              true,
 	}
 
 	// test the case where where everything is set properly
@@ -55,7 +56,8 @@ func (suite *ConfigTestSuite) TestLoadFromJson() {
   "verify_ssl": true,
   "tls_enabled": false,
   "trust_unknown_cas": true,
-  "log_level": "INFO"
+  "log_level": "INFO",
+  "skip_subs_load": true
 }
 `
 	cfg := new(Config)
@@ -73,6 +75,7 @@ func (suite *ConfigTestSuite) TestLoadFromJson() {
 	suite.Equal(false, cfg.TLSEnabled)
 	suite.Equal(true, cfg.TrustUnknownCAs)
 	suite.Equal("INFO", cfg.LogLevel)
+	suite.Equal(true, cfg.SkipSubsLoad)
 
 	suite.Nil(e1)
 

--- a/config/mock.go
+++ b/config/mock.go
@@ -12,5 +12,6 @@ func NewMockConfig() *Config {
 	cfg.AmsPort = 8080
 	cfg.VerifySSL = true
 	cfg.TrustUnknownCAs = false
+	cfg.SkipSubsLoad = true
 	return cfg
 }

--- a/push/linearworker.go
+++ b/push/linearworker.go
@@ -22,6 +22,11 @@ type LinearWorker struct {
 	pushErr          string
 }
 
+// Consumer returns the currently in use consumer
+func (w *LinearWorker) Consumer() consumers.Consumer {
+	return w.consumer
+}
+
 // NewLinearWorker initialises and configures a new linear worker
 func NewLinearWorker(sub *amsPb.Subscription, c consumers.Consumer, s senders.Sender, ch chan<- consumers.CancelableError) *LinearWorker {
 	lw := new(LinearWorker)

--- a/push/linearworker_test.go
+++ b/push/linearworker_test.go
@@ -223,6 +223,16 @@ func (suite *LinearWorkerTestSuite) TestPush() {
 	}, <-cancelCh2)
 }
 
+func (suite *LinearWorkerTestSuite) TestConsumer() {
+
+	mc := new(consumers.MockConsumer)
+	lw := LinearWorker{
+		consumer: mc,
+	}
+
+	suite.Equal(mc, lw.consumer)
+}
+
 func TestLinearWorkerTestSuite(t *testing.T) {
 	logrus.SetOutput(ioutil.Discard)
 	suite.Run(t, new(LinearWorkerTestSuite))

--- a/push/mock.go
+++ b/push/mock.go
@@ -1,11 +1,18 @@
 package push
 
-import amsPb "github.com/ARGOeu/ams-push-server/api/v1/grpc/proto"
+import (
+	amsPb "github.com/ARGOeu/ams-push-server/api/v1/grpc/proto"
+	"github.com/ARGOeu/ams-push-server/consumers"
+)
 
 // MockWorker is to be used as a dummy worker when we want the push actual worker functionality
 type MockWorker struct {
 	Sub    amsPb.Subscription
 	Status string
+}
+
+func (w *MockWorker) Consumer() consumers.Consumer {
+	return new(consumers.MockConsumer)
 }
 
 func (w *MockWorker) Subscription() *amsPb.Subscription {

--- a/push/worker.go
+++ b/push/worker.go
@@ -12,6 +12,8 @@ type PushError struct {
 	SubName string
 }
 
+type WorkerStatus string
+
 // Worker encapsulates the flow of consuming, sending and acknowledging
 type Worker interface {
 	// Start starts the the push functionality based on the type of the worker
@@ -20,6 +22,8 @@ type Worker interface {
 	Stop()
 	// Subscription returns the currently active subscription that is being handled by the worker
 	Subscription() *amsPb.Subscription
+	// Consumer returns the consumer that the worker is using
+	Consumer() consumers.Consumer
 }
 
 // New acts as a worker factory, creates and returns a new worker based on the provided type


### PR DESCRIPTION
Upon starting up, the push server communicates with ams and retrieve all push-enabled subscriptions. Following the acl based solution, the push server finds itself as a user in ams(the **ams_token** in the push server's configuration should match the **push_worker_token** in ams's configuration) and for each of its projects examine all subscriptions for push enabled configuration. If a subscription is successfully retrieved and has a push config, we activate it in order to start the push functionality(consume->send->ack). We also check to see the push status of s subscription when we retrieve it.If its not a success status we update it as well.