### PR TITLE
Remove unused downstream job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,9 +63,6 @@ pipeline {
         }
         success {
             script{
-                if ( env.BRANCH_NAME == 'devel' ) {
-                    build job: '/ARGO-utils/argo-swagger-docs', propagate: false
-                }
                 if ( env.BRANCH_NAME == 'master' || env.BRANCH_NAME == 'devel' ) {
                     slackSend( message: ":rocket: New version for <$BUILD_URL|$PROJECT_DIR>:$BRANCH_NAME Job: $JOB_NAME !")
                 }


### PR DESCRIPTION
This is an old downstream job used to deploy documentation updates to the swagger site. However the ams-push-server doesn't have any swagger docs and it was added by a mistake.

Removing job to run jenkins job without errors