### PR TITLE
AM-212 ams-push-server: Group the internal ams http functionality under a single client

### DIFF
--- a/api/v1/grpc/server.go
+++ b/api/v1/grpc/server.go
@@ -1,14 +1,13 @@
 package grpc
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	amsPb "github.com/ARGOeu/ams-push-server/api/v1/grpc/proto"
 	"github.com/ARGOeu/ams-push-server/config"
 	"github.com/ARGOeu/ams-push-server/consumers"
+	ams "github.com/ARGOeu/ams-push-server/pkg/ams/v1"
 	"github.com/ARGOeu/ams-push-server/push"
 	"github.com/ARGOeu/ams-push-server/senders"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
@@ -36,6 +35,7 @@ const ServiceUnavailable = "The push service is currently unable to handle any r
 type PushService struct {
 	Cfg            *config.Config
 	Client         *http.Client
+	AmsClient      *ams.Client
 	PushWorkers    map[string]push.Worker
 	deactivateChan chan consumers.CancelableError
 	status         string
@@ -62,6 +62,7 @@ func NewPushService(cfg *config.Config) *PushService {
 	}
 
 	ps.Client = client
+	ps.AmsClient = ams.NewClient("https", ps.Cfg.AmsHost, ps.Cfg.AmsToken, ps.Cfg.AmsPort, client)
 
 	ps.deactivateChan = make(chan consumers.CancelableError)
 	go ps.handleDeactivateChannel()
@@ -142,7 +143,7 @@ func (ps *PushService) ActivateSubscription(ctx context.Context, r *amsPb.Activa
 	}
 
 	// choose a consumer
-	c, _ := consumers.New(consumers.AmsHttpConsumerType, r.Subscription.FullName, ps.Cfg, ps.Client)
+	c, _ := consumers.New(consumers.AmsHttpConsumerType, r.Subscription.FullName, ps.AmsClient)
 
 	// choose a sender
 	s, _ := senders.New(senders.HttpSenderType, *r.Subscription.PushConfig, ps.Client)
@@ -240,16 +241,18 @@ func NewGRPCServer(cfg *config.Config) *grpc.Server {
 	return srv
 }
 
-// loadSubscriptions activates all the ams subscriptions that are push enabled and assigned to the current push server
+// loadSubscriptions activates all the ams subscriptions that are push enabled and assigned to the current push worker
 func (ps *PushService) loadSubscriptions() {
 
-	var userInfo UserInfo
+	var userInfo ams.UserInfo
 	var err error
 
 	userFound := false
 
+	// attempt to retrieve the push worker user
 	for !userFound {
-		userInfo, err = ps.getPushWorkerUser()
+		t1 := time.Now()
+		userInfo, err = ps.AmsClient.GetUserByToken(context.Background(), ps.Cfg.AmsToken)
 		if err != nil {
 			ps.status = "Could not retrieve push worker user"
 			log.WithFields(
@@ -261,6 +264,13 @@ func (ps *PushService) loadSubscriptions() {
 			continue
 		}
 		userFound = true
+		log.WithFields(
+			log.Fields{
+				"type":            "performance_log",
+				"user":            userInfo.Name,
+				"processing_time": time.Since(t1).String(),
+			},
+		).Info("Push worker user retrieved successfully")
 	}
 
 	ps.status = "ok"
@@ -271,7 +281,8 @@ func (ps *PushService) loadSubscriptions() {
 
 			fullSubName := fmt.Sprintf("/projects/%v/subscriptions/%v", project.Project, subName)
 
-			sub, err := ps.getSubscription(fullSubName)
+			t1 := time.Now()
+			sub, err := ps.AmsClient.GetSubscription(context.Background(), fullSubName)
 			if err != nil {
 				log.WithFields(
 					log.Fields{
@@ -283,7 +294,7 @@ func (ps *PushService) loadSubscriptions() {
 				continue
 			}
 
-			if sub.PushCfg == (PushConfig{}) {
+			if !sub.IsPushEnabled() {
 				log.WithFields(
 					log.Fields{
 						"type":         "system_log",
@@ -292,6 +303,14 @@ func (ps *PushService) loadSubscriptions() {
 				).Error("Subscription is not push enabled")
 				continue
 			}
+
+			log.WithFields(
+				log.Fields{
+					"type":            "performance_log",
+					"subscription":    sub.FullName,
+					"processing_time": time.Since(t1).String(),
+				},
+			).Info("Subscription retrieved successfully")
 
 			_, err = ps.ActivateSubscription(context.TODO(),
 				&amsPb.ActivateSubscriptionRequest{
@@ -330,136 +349,4 @@ func (ps *PushService) loadSubscriptions() {
 			).Info("Subscription activated successfully")
 		}
 	}
-}
-
-// getPushWorkerUser uses the provided token to get the respective push worker user profile
-func (ps *PushService) getPushWorkerUser() (UserInfo, error) {
-
-	url := fmt.Sprintf("https://%v:%v/v1/users:byToken/%v?key=%v",
-		ps.Cfg.AmsHost, ps.Cfg.AmsPort, ps.Cfg.AmsToken, ps.Cfg.AmsToken)
-
-	req, err := http.NewRequest(http.MethodGet, url, bytes.NewBuffer(nil))
-	if err != nil {
-		return UserInfo{}, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	t1 := time.Now()
-
-	resp, err := ps.Client.Do(req)
-	if err != nil {
-		return UserInfo{}, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		buf := bytes.Buffer{}
-		buf.ReadFrom(resp.Body)
-		return UserInfo{}, errors.New(buf.String())
-	}
-
-	userInfo := UserInfo{}
-
-	err = json.NewDecoder(resp.Body).Decode(&userInfo)
-	if err != nil {
-		return UserInfo{}, err
-	}
-
-	log.WithFields(
-		log.Fields{
-			"type":            "performance_log",
-			"user":            userInfo.Name,
-			"processing_time": time.Since(t1).String(),
-		},
-	).Info("Push worker user retrieved successfully")
-
-	return userInfo, nil
-}
-
-// getSubscription retrieves the detailed information for a specific subscription
-func (ps *PushService) getSubscription(fullSub string) (Subscription, error) {
-
-	url := fmt.Sprintf("https://%v:%v/v1%v?key=%v",
-		ps.Cfg.AmsHost, ps.Cfg.AmsPort, fullSub, ps.Cfg.AmsToken)
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-
-	if err != nil {
-		return Subscription{}, err
-	}
-
-	req.Header.Set("Content-type", "application/json")
-
-	t1 := time.Now()
-	resp, err := ps.Client.Do(req)
-
-	if err != nil {
-		return Subscription{}, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		buf := bytes.Buffer{}
-		buf.ReadFrom(resp.Body)
-		return Subscription{}, errors.New(buf.String())
-	}
-
-	sub := Subscription{}
-	err = json.NewDecoder(resp.Body).Decode(&sub)
-	if err != nil {
-		return Subscription{}, err
-	}
-
-	log.WithFields(
-		log.Fields{
-			"type":            "performance_log",
-			"subscription":    sub.FullName,
-			"processing_time": time.Since(t1).String(),
-		},
-	).Info("Subscription retrieved successfully")
-
-	return sub, nil
-}
-
-type UserInfo struct {
-	Name     string    `json:"name"`
-	Projects []Project `json:"projects"`
-}
-
-type Subscription struct {
-	FullName   string     `json:"name"`
-	FullTopic  string     `json:"topic"`
-	PushCfg    PushConfig `json:"pushConfig"`
-	PushStatus string     `json:"push_status"`
-}
-
-// PushConfig holds optional configuration for push operations
-type PushConfig struct {
-	Pend                string              `json:"pushEndpoint"`
-	AuthorizationHeader AuthorizationHeader `json:"authorization_header"`
-	MaxMessages         int64               `json:"maxMessages"`
-	RetPol              RetryPolicy         `json:"retryPolicy"`
-}
-
-// AuthorizationHeader holds an optional value to be supplied as an Authorization header to push requests
-type AuthorizationHeader struct {
-	Value string `json:"value"`
-}
-
-// RetryPolicy holds information on retry policies
-type RetryPolicy struct {
-	PolicyType string `json:"type,omitempty"`
-	Period     uint32 `json:"period,omitempty"`
-}
-
-type Projects struct {
-	Projects []Project `json:"projects"`
-}
-
-type Project struct {
-	Project       string   `json:"project"`
-	Subscriptions []string `json:"subscriptions"`
 }

--- a/api/v1/grpc/server_test.go
+++ b/api/v1/grpc/server_test.go
@@ -1,12 +1,11 @@
 package grpc
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	amsPb "github.com/ARGOeu/ams-push-server/api/v1/grpc/proto"
 	"github.com/ARGOeu/ams-push-server/config"
 	"github.com/ARGOeu/ams-push-server/consumers"
+	ams "github.com/ARGOeu/ams-push-server/pkg/ams/v1"
 	"github.com/ARGOeu/ams-push-server/push"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
@@ -15,7 +14,6 @@ import (
 	"google.golang.org/grpc/status"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"testing"
 )
 
@@ -240,88 +238,15 @@ func (suite *ServerTestSuite) TestNewGRPCServer() {
 	suite.IsType(&grpc.Server{}, srv)
 }
 
-func (suite *ServerTestSuite) TestGetPushWorkerUser() {
-
-	ps := NewPushService(config.NewMockConfig())
-	client := &http.Client{
-		Transport: new(MockRoundTripper),
-	}
-	ps.Client = client
-
-	u1, err1 := ps.getPushWorkerUser()
-
-	p1 := Project{
-		Project:       "push1",
-		Subscriptions: []string{"sub1", "errorsub"},
-	}
-
-	p2 := Project{
-		Project:       "push2",
-		Subscriptions: []string{"sub3", "sub4"},
-	}
-
-	expectedUSerInfo := UserInfo{
-		Name:     "worker",
-		Projects: []Project{p1, p2},
-	}
-
-	suite.Equal(expectedUSerInfo, u1)
-	suite.Nil(err1)
-
-	// error case
-	ps.Cfg.AmsToken = "errortoken"
-	u2, err2 := ps.getPushWorkerUser()
-	suite.Equal(UserInfo{}, u2)
-	suite.Equal("server internal error", err2.Error())
-}
-
-func (suite *ServerTestSuite) TestGetSubscription() {
-
-	ps := NewPushService(config.NewMockConfig())
-	client := &http.Client{
-		Transport: new(MockRoundTripper),
-	}
-	ps.Client = client
-
-	rp := RetryPolicy{
-		PolicyType: "linear",
-		Period:     300,
-	}
-
-	authz := AuthorizationHeader{
-		Value: "auth-header-1",
-	}
-
-	pc := PushConfig{
-		Pend:                "example.com:9999",
-		AuthorizationHeader: authz,
-		RetPol:              rp,
-	}
-
-	expectedSub := Subscription{
-		FullName:  "/projects/push1/subscriptions/sub1",
-		FullTopic: "/projects/push1/topics/t1",
-		PushCfg:   pc,
-	}
-
-	sub1, err1 := ps.getSubscription("/projects/push1/subscriptions/sub1")
-	suite.Equal(expectedSub, sub1)
-	suite.Nil(err1)
-
-	// error case
-	sub2, err2 := ps.getSubscription("/projects/push1/subscriptions/errorsub")
-	suite.Equal(Subscription{}, sub2)
-	suite.Equal("server internal error", err2.Error())
-
-}
-
 func (suite *ServerTestSuite) TestLoadSubscriptions() {
 
 	ps := NewPushService(config.NewMockConfig())
 	client := &http.Client{
-		Transport: new(MockRoundTripper),
+		Transport: new(ams.MockAmsRoundTripper),
 	}
 	ps.Client = client
+	amsClient := ams.NewClient("", "", "", 443, client)
+	ps.AmsClient = amsClient
 
 	ps.loadSubscriptions()
 
@@ -348,151 +273,4 @@ func (suite *ServerTestSuite) TestLoadSubscriptions() {
 func TestServerTestSuite(t *testing.T) {
 	logrus.SetOutput(ioutil.Discard)
 	suite.Run(t, new(ServerTestSuite))
-}
-
-type MockRoundTripper struct{}
-
-func (m *MockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	var resp *http.Response
-
-	header := make(http.Header)
-	header.Set("Content-type", "application/json")
-
-	switch r.URL.Path {
-
-	case "/v1/users:byToken/sometoken":
-
-		p1 := Project{
-			Project:       "push1",
-			Subscriptions: []string{"sub1", "errorsub"},
-		}
-
-		p2 := Project{
-			Project:       "push2",
-			Subscriptions: []string{"sub3", "sub4"},
-		}
-
-		userInfo := UserInfo{
-			Name:     "worker",
-			Projects: []Project{p1, p2},
-		}
-
-		b, _ := json.Marshal(userInfo)
-
-		resp = &http.Response{
-			StatusCode: 200,
-			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewReader(b)),
-			// Must be set to non-nil value or it panics
-			Header: header,
-		}
-	case "/v1/users:byToken/errortoken":
-
-		resp = &http.Response{
-			StatusCode: 500,
-			// Send response to be tested
-			Body: ioutil.NopCloser(strings.NewReader("server internal error")),
-			// Must be set to non-nil value or it panics
-			Header: header,
-		}
-
-	case "/v1/projects/push1/subscriptions/sub1":
-
-		rp := RetryPolicy{
-			PolicyType: "linear",
-			Period:     300,
-		}
-		authz := AuthorizationHeader{
-			Value: "auth-header-1",
-		}
-
-		pc := PushConfig{
-			Pend:                "example.com:9999",
-			AuthorizationHeader: authz,
-			RetPol:              rp,
-		}
-
-		s := Subscription{
-			FullName:  "/projects/push1/subscriptions/sub1",
-			FullTopic: "/projects/push1/topics/t1",
-			PushCfg:   pc,
-		}
-
-		sb, _ := json.Marshal(s)
-
-		resp = &http.Response{
-			StatusCode: 200,
-			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewReader(sb)),
-			// Must be set to non-nil value or it panics
-			Header: header,
-		}
-
-	case "/v1/projects/push1/subscriptions/errorsub":
-
-		resp = &http.Response{
-			StatusCode: 500,
-			// Send response to be tested
-			Body: ioutil.NopCloser(strings.NewReader("server internal error")),
-			// Must be set to non-nil value or it panics
-			Header: header,
-		}
-
-	case "/v1/projects/push2/subscriptions/sub3":
-
-		s := Subscription{
-			FullName:  "/projects/push2/subscriptions/sub3",
-			FullTopic: "/projects/push2/topics/t1",
-		}
-
-		sb, _ := json.Marshal(s)
-
-		resp = &http.Response{
-			StatusCode: 200,
-			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewReader(sb)),
-			// Must be set to non-nil value or it panics
-			Header: header,
-		}
-
-	case "/v1/projects/push2/subscriptions/sub4":
-
-		rp := RetryPolicy{
-			PolicyType: "linear",
-			Period:     300,
-		}
-
-		pc := PushConfig{
-			Pend:   "example.com:9999",
-			RetPol: rp,
-		}
-
-		s := Subscription{
-			FullName:  "/projects/push2/subscriptions/sub4",
-			FullTopic: "/projects/push2/topics/t1",
-			PushCfg:   pc,
-		}
-
-		sb, _ := json.Marshal(s)
-
-		resp = &http.Response{
-			StatusCode: 200,
-			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewReader(sb)),
-			// Must be set to non-nil value or it panics
-			Header: header,
-		}
-
-	default:
-		resp = &http.Response{
-			StatusCode: 500,
-			// Send response to be tested
-			Body: ioutil.NopCloser(strings.NewReader("unexpected outcome")),
-			// Must be set to non-nil value or it panics
-			Header: header,
-		}
-
-	}
-
-	return resp, nil
 }

--- a/consumers/amshttpconsumer.go
+++ b/consumers/amshttpconsumer.go
@@ -1,14 +1,12 @@
 package consumers
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	ams "github.com/ARGOeu/ams-push-server/pkg/ams/v1"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-	"strconv"
 	"time"
 )
 
@@ -18,69 +16,10 @@ const (
 	SubscriptionNotFound = "Subscription doesn't exist"
 )
 
-type PushStatus struct {
-	PushStatus string `json:"push_status"`
-}
-
-// Attributes is key/value pairs of extra data
-type Attributes map[string]string
-
-// PullOptions holds information on how we want to pull messages
-type PullOptions struct {
-	// amount of messages to be pulled at once
-	MaxMessages string `json:"maxMessages"`
-	// whether or not it should wait until it gathers
-	// the requested amount of maxMessages
-	// to be pulled or return with what is available
-	ReturnImmediately string `json:"returnImmediately"`
-}
-
-// Message struct used to hold message information
-type Message struct {
-	// message id
-	ID string `json:"messageId,omitempty"`
-	// used to hold attribute key/value store
-	Attr Attributes `json:"attributes,omitempty"`
-	// base64 encoded data payload
-	Data string `json:"data"`
-	// publish time date of message
-	PubTime string `json:"publishTime,omitempty"`
-}
-
-// ReceivedMessage holds info for a received message
-type ReceivedMessage struct {
-	// id to be used for acknowledgement
-	AckID string `json:"ackId,omitempty"`
-	// the message itself
-	Msg Message `json:"message"`
-}
-
-// ReceivedMessagesList holds the array of the receivedMessages - subscription related
-type ReceivedMessagesList struct {
-	RecMsgs []ReceivedMessage `json:"receivedMessages"`
-}
-
-// IsEmpty returns whether or not a received message list is empty
-func (r *ReceivedMessagesList) IsEmpty() bool {
-	return len(r.RecMsgs) <= 0
-}
-
-// Last returns the last ReceivedMessage of the slice
-func (r *ReceivedMessagesList) Last() ReceivedMessage {
-	return r.RecMsgs[len(r.RecMsgs)-1]
-}
-
-// AckMsgs the ack ids for the messages we want to acknowledge
-type AckMsgs struct {
-	AckIDS []string `json:"ackIds"`
-}
-
 // AmsHttpConsumer is a consumer that helps us interface with AMS through its rest api
 type AmsHttpConsumer struct {
-	client   *http.Client
-	endpoint string
-	fullSub  string
-	token    string
+	fullSub   string
+	amsClient *ams.Client
 }
 
 // AmsHttpError represents the layout of an ams http api error
@@ -96,12 +35,10 @@ type amsErr struct {
 }
 
 // NewAmsHttpConsumer initialises and returns a new ams http consumer
-func NewAmsHttpConsumer(endpoint, fullSub, token string, client *http.Client) *AmsHttpConsumer {
+func NewAmsHttpConsumer(fullSub string, amsClient *ams.Client) *AmsHttpConsumer {
 	ahc := new(AmsHttpConsumer)
-	ahc.client = client
-	ahc.endpoint = endpoint
 	ahc.fullSub = fullSub
-	ahc.token = token
+	ahc.amsClient = amsClient
 	return ahc
 }
 
@@ -128,30 +65,12 @@ func (ahc *AmsHttpConsumer) ToCancelableError(error error) (CancelableError, boo
 
 // ResourceInfo returns the ams subscription and the ams host it is on
 func (ahc *AmsHttpConsumer) ResourceInfo() string {
-	return fmt.Sprintf("subscription %v from %v", ahc.fullSub, ahc.endpoint)
+	return fmt.Sprintf("subscription %v from %v", ahc.fullSub, ahc.amsClient.Host())
 }
 
 // Consume consumes messages from an subscription
-func (ahc *AmsHttpConsumer) Consume(ctx context.Context, numberOfMessages int64) (ReceivedMessagesList, error) {
+func (ahc *AmsHttpConsumer) Consume(ctx context.Context, numberOfMessages int64) (ams.ReceivedMessagesList, error) {
 
-	url := fmt.Sprintf("https://%v/v1%v:pull?key=%v", ahc.endpoint, ahc.fullSub, ahc.token)
-
-	pullOptions := PullOptions{
-		MaxMessages:       strconv.FormatInt(numberOfMessages, 10),
-		ReturnImmediately: "true",
-	}
-
-	pullOptB, err := json.Marshal(pullOptions)
-	if err != nil {
-		return ReceivedMessagesList{}, err
-	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(pullOptB))
-	if err != nil {
-		return ReceivedMessagesList{}, err
-	}
-
-	req.Header.Set("Content-Type", ApplicationJson)
 	log.WithFields(
 		log.Fields{
 			"type":     "service_log",
@@ -161,27 +80,13 @@ func (ahc *AmsHttpConsumer) Consume(ctx context.Context, numberOfMessages int64)
 
 	t1 := time.Now()
 
-	resp, err := ahc.client.Do(req.WithContext(ctx))
+	reqList, err := ahc.amsClient.Pull(ctx, ahc.fullSub, numberOfMessages, true)
 	if err != nil {
-		return ReceivedMessagesList{}, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		buf := bytes.Buffer{}
-		buf.ReadFrom(resp.Body)
-		return ReceivedMessagesList{}, errors.New(buf.String())
-	}
-
-	reqList := ReceivedMessagesList{}
-	err = json.NewDecoder(resp.Body).Decode(&reqList)
-	if err != nil {
-		return reqList, err
+		return ams.ReceivedMessagesList{}, err
 	}
 
 	if reqList.IsEmpty() {
-		return ReceivedMessagesList{}, errors.New("no new messages")
+		return ams.ReceivedMessagesList{}, errors.New("no new messages")
 	}
 
 	log.WithFields(
@@ -198,39 +103,12 @@ func (ahc *AmsHttpConsumer) Consume(ctx context.Context, numberOfMessages int64)
 
 // Ack acknowledges that an ams message has been consumed and processed
 func (ahc *AmsHttpConsumer) Ack(ctx context.Context, ackId string) error {
-
-	ack := AckMsgs{AckIDS: []string{ackId}}
-
-	ackB, err := json.Marshal(ack)
-	if err != nil {
-		return err
-	}
-
-	url := fmt.Sprintf("https://%v/v1%v:acknowledge?key=%v", ahc.endpoint, ahc.fullSub, ahc.token)
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(ackB))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", ApplicationJson)
-
 	t1 := time.Now()
-
-	resp, err := ahc.client.Do(req.WithContext(ctx))
+	err := ahc.amsClient.Ack(ctx, ahc.fullSub, ackId)
 	if err != nil {
-		return err
+		return fmt.Errorf("an error occurred while trying to acknowledge message with ackId %v from %v, %v",
+			ackId, ahc.ResourceInfo(), err.Error())
 	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		buf := bytes.Buffer{}
-		buf.ReadFrom(resp.Body)
-		err = fmt.Errorf("an error occurred while trying to acknowledge message with ackId %v from %v, %v", ackId, ahc.ResourceInfo(), buf.String())
-		return err
-	}
-
 	log.WithFields(
 		log.Fields{
 			"type":            "performance",
@@ -239,54 +117,6 @@ func (ahc *AmsHttpConsumer) Ack(ctx context.Context, ackId string) error {
 			"processing_time": time.Since(t1).String(),
 		},
 	).Debug("Message acknowledged")
-
-	return nil
-}
-
-// UpdateResourceStatus updates the subscription's status
-func (ahc *AmsHttpConsumer) UpdateResourceStatus(ctx context.Context, status string) error {
-
-	pushStatus := PushStatus{
-		PushStatus: status,
-	}
-
-	pushB, err := json.Marshal(pushStatus)
-	if err != nil {
-		return err
-	}
-
-	url := fmt.Sprintf("https://%v/v1%v:modifyPushStatus?key=%v", ahc.endpoint, ahc.fullSub, ahc.token)
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(pushB))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", ApplicationJson)
-
-	t1 := time.Now()
-
-	resp, err := ahc.client.Do(req.WithContext(ctx))
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		buf := bytes.Buffer{}
-		buf.ReadFrom(resp.Body)
-		return errors.New(buf.String())
-	}
-
-	log.WithFields(
-		log.Fields{
-			"type":            "performance",
-			"status":          status,
-			"resource":        ahc.ResourceInfo(),
-			"processing_time": time.Since(t1).String(),
-		},
-	).Info("Resource status updated")
 
 	return nil
 }

--- a/consumers/amshttpconsumer_test.go
+++ b/consumers/amshttpconsumer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	ams "github.com/ARGOeu/ams-push-server/pkg/ams/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 	"io/ioutil"
@@ -18,30 +19,32 @@ type AmsHttpConsumerTestSuite struct {
 // TestNewAmsHttpConsumer tests the proper initialization of an ams http consumer
 func (suite *AmsHttpConsumerTestSuite) TestNewAmsHttpConsumer() {
 
-	ahc := NewAmsHttpConsumer("example.com:443", "/projects/p1/subscriptions/s1", "some_token", new(http.Client))
+	ahc := NewAmsHttpConsumer("/projects/p1/subscriptions/s1",
+		ams.NewClient("https", "example.com", "token", 443, new(http.Client)))
 
-	suite.Equal("example.com:443", ahc.endpoint)
+	suite.Equal("example.com:443", ahc.amsClient.Host())
 	suite.Equal("/projects/p1/subscriptions/s1", ahc.fullSub)
-	suite.Equal("some_token", ahc.token)
-	suite.Equal(new(http.Client), ahc.client)
+	suite.NotNil(ahc.amsClient)
 }
 
 // TestConsume tests various behaviors of the consume functionality
 func (suite *AmsHttpConsumerTestSuite) TestConsume() {
 
-	mcrt := new(MockConsumeRoundTripper)
+	mcrt := new(ams.MockConsumeRoundTripper)
 
 	client := &http.Client{
 		Transport: mcrt,
 	}
 
+	amsClient := ams.NewClient("https", "localhost", "token", 443, client)
+
 	// test the normal case, where the consume method will return new messages
-	acl := NewAmsHttpConsumer("", "/normal_sub", "", client)
+	acl := NewAmsHttpConsumer("/normal_sub", amsClient)
 
 	m1, e1 := acl.Consume(context.Background(), 1)
 
 	// check pull options(request body)
-	po := PullOptions{}
+	po := ams.PullOptions{}
 	json.Unmarshal(mcrt.RequestBodyBytes, &po)
 
 	suite.Equal("some_data", m1.RecMsgs[0].Msg.Data)
@@ -51,14 +54,14 @@ func (suite *AmsHttpConsumerTestSuite) TestConsume() {
 	suite.Nil(e1)
 
 	// check for multiple messages
-	po2 := PullOptions{}
+	po2 := ams.PullOptions{}
 	mcrt.RequestBodyBytes = []byte{}
 	acl.Consume(context.Background(), 3)
 	json.Unmarshal(mcrt.RequestBodyBytes, &po2)
 	suite.Equal("3", po2.MaxMessages)
 
 	// test the case where there are no new messages
-	acl2 := NewAmsHttpConsumer("", "/empty_sub", "", client)
+	acl2 := NewAmsHttpConsumer("/empty_sub", amsClient)
 
 	m2, e2 := acl2.Consume(context.Background(), 1)
 
@@ -66,7 +69,7 @@ func (suite *AmsHttpConsumerTestSuite) TestConsume() {
 	suite.Equal("no new messages", e2.Error())
 
 	// test the case where an error occurred while interacting with ams
-	acl3 := NewAmsHttpConsumer("e1", "/error_sub", "", client)
+	acl3 := NewAmsHttpConsumer("/error_sub", amsClient)
 
 	_, e3 := acl3.Consume(context.Background(), 1)
 
@@ -81,7 +84,7 @@ func (suite *AmsHttpConsumerTestSuite) TestConsume() {
 	suite.Equal(expOut, e3.Error())
 
 	// test the case where an error occurred while interacting with ams(project not found)
-	acl4 := NewAmsHttpConsumer("e1", "/error_sub_no_project", "", client)
+	acl4 := NewAmsHttpConsumer("/error_sub_no_project", amsClient)
 
 	_, e4 := acl4.Consume(context.Background(), 1)
 
@@ -96,7 +99,7 @@ func (suite *AmsHttpConsumerTestSuite) TestConsume() {
 	suite.Equal(expOut2, e4.Error())
 
 	// test the case where an error occurred while interacting with ams(subscription not found)
-	acl5 := NewAmsHttpConsumer("e1", "/error_sub_no_sub", "", client)
+	acl5 := NewAmsHttpConsumer("/error_sub_no_sub", amsClient)
 
 	_, e5 := acl5.Consume(context.Background(), 1)
 
@@ -113,7 +116,8 @@ func (suite *AmsHttpConsumerTestSuite) TestConsume() {
 
 func (suite *AmsHttpConsumerTestSuite) TestResourceInfo() {
 
-	ahc := NewAmsHttpConsumer("example.com:443", "/projects/p1/subscriptions/s1", "some_token", new(http.Client))
+	ahc := NewAmsHttpConsumer("/projects/p1/subscriptions/s1",
+		ams.NewClient("https", "example.com", "token", 443, new(http.Client)))
 
 	suite.Equal("subscription /projects/p1/subscriptions/s1 from example.com:443", ahc.ResourceInfo())
 }
@@ -122,22 +126,24 @@ func (suite *AmsHttpConsumerTestSuite) TestResourceInfo() {
 func (suite *AmsHttpConsumerTestSuite) TestAck() {
 
 	client := &http.Client{
-		Transport: new(MockConsumeRoundTripper),
+		Transport: new(ams.MockConsumeRoundTripper),
 	}
 
+	amsClient := ams.NewClient("https", "localhost", "token", 443, client)
+
 	// test the normal case, where the acknowledgement is successful
-	acl := NewAmsHttpConsumer("", "/normal_sub", "", client)
+	acl := NewAmsHttpConsumer("/normal_sub", amsClient)
 
 	e1 := acl.Ack(context.Background(), "ackid")
 
 	suite.Nil(e1)
 
 	// test the normal case, where the acknowledgement has timed out
-	acl2 := NewAmsHttpConsumer("e1", "/timeout_sub", "", client)
+	acl2 := NewAmsHttpConsumer("/timeout_sub", amsClient)
 
 	e2 := acl2.Ack(context.Background(), "ackid-15")
 
-	expOut := `an error occurred while trying to acknowledge message with ackId ackid-15 from subscription /timeout_sub from e1, {
+	expOut := `an error occurred while trying to acknowledge message with ackId ackid-15 from subscription /timeout_sub from localhost:443, {
 		 "error": {
 			"code": 408,
 			"message": "ack timeout",
@@ -150,7 +156,7 @@ func (suite *AmsHttpConsumerTestSuite) TestAck() {
 
 func (suite *AmsHttpConsumerTestSuite) TestToCancelableError() {
 
-	c := NewAmsHttpConsumer("", "normal_sub", "", nil)
+	c := NewAmsHttpConsumer("normal_sub", nil)
 
 	errorMsg1 := `{
 		 "error": {
@@ -187,35 +193,6 @@ func (suite *AmsHttpConsumerTestSuite) TestToCancelableError() {
 	ce3, ok3 := c.ToCancelableError(errors.New(errorMsg3))
 	suite.False(ok3)
 	suite.Equal(CancelableError{}, ce3)
-}
-
-func (suite *AmsHttpConsumerTestSuite) TestUpdateResourceStatus() {
-
-	client := &http.Client{
-		Transport: new(MockConsumeRoundTripper),
-	}
-
-	// normal case
-	c := NewAmsHttpConsumer("e2", "/normal_sub", "", client)
-
-	e1 := c.UpdateResourceStatus(context.Background(), "")
-
-	suite.Nil(e1)
-
-	// test the case where an error occurred while interacting with ams
-	c = NewAmsHttpConsumer("e2", "/error_sub", "", client)
-
-	e2 := c.UpdateResourceStatus(context.Background(), "")
-
-	expOut := `{
-		 "error": {
-			"code": 500,
-			"message": "Internal error",
-			"status": "INTERNAL_ERROR"
-		 }
-		}`
-
-	suite.Equal(expOut, e2.Error())
 }
 
 func TestAmsHttpConsumerTestSuite(t *testing.T) {

--- a/consumers/consumer_test.go
+++ b/consumers/consumer_test.go
@@ -1,7 +1,7 @@
 package consumers
 
 import (
-	"github.com/ARGOeu/ams-push-server/config"
+	ams "github.com/ARGOeu/ams-push-server/pkg/ams/v1"
 	"github.com/stretchr/testify/suite"
 	"net/http"
 	"testing"
@@ -14,18 +14,15 @@ type ConsumerTestSuite struct {
 // TestNew tests that the consumer factory behaves properly
 func (suite *ConsumerTestSuite) TestNew() {
 
-	cfg := new(config.Config)
-	cfg.AmsPort = 8080
-	cfg.AmsHost = "localhost"
-
 	// normal creation
-	c, e1 := New(AmsHttpConsumerType, "/projects/p1/subscriptions/s1", cfg, &http.Client{})
+	c, e1 := New(AmsHttpConsumerType, "/projects/p1/subscriptions/s1",
+		ams.NewClient("https", "localhost", "token", 8080, new(http.Client)))
 	suite.IsType(&AmsHttpConsumer{}, c)
 	suite.Equal("subscription /projects/p1/subscriptions/s1 from localhost:8080", c.ResourceInfo())
 	suite.Nil(e1)
 
 	// unimplemented consumer
-	_, e2 := New("unknown", "", nil, nil)
+	_, e2 := New("unknown", "", nil)
 	suite.Equal("consumer unknown not yet implemented", e2.Error())
 
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/gogo/protobuf v1.3.1 // indirect
-	github.com/golang/protobuf v1.2.1-0.20181120001857-882cf97a83ad
+	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,10 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.1-0.20181120001857-882cf97a83ad h1:bSbAkqfd9+R23vsRI25fhAMW7iLIV4YxPgMsTtBEEEY=
 github.com/golang/protobuf v1.2.1-0.20181120001857-882cf97a83ad/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -46,6 +50,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -53,4 +58,7 @@ google.golang.org/genproto v0.0.0-20181109154231-b5d43981345b h1:WkFtVmaZoTRVoRY
 google.golang.org/genproto v0.0.0-20181109154231-b5d43981345b/go.mod h1:7Ep/1NZk928CDR8SjdVbjWNpdIf6nzjE3BTgJDr2Atg=
 google.golang.org/grpc v1.16.0 h1:dz5IJGuC2BB7qXR5AyHNwAUBhZscK2xVez7mznh72sY=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/ams/v1/client.go
+++ b/pkg/ams/v1/client.go
@@ -1,0 +1,92 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Client encapsulates all the possible api calls that a client can use to interface with the ams service
+type Client struct {
+	*UserService
+	*SubscriptionService
+	*MessageService
+}
+
+// AmsBaseInfo holds basic information to interact with the ams service
+type AmsBaseInfo struct {
+	Scheme  string
+	Host    string
+	Headers map[string]string
+}
+
+// NewClient properly initialises a new ams client
+func NewClient(scheme, host, token string, port int, client *http.Client) *Client {
+	baseInfo := AmsBaseInfo{
+		Scheme: scheme,
+		Host:   fmt.Sprintf("%s:%v", host, port),
+		Headers: map[string]string{
+			"Content-type": "application/json",
+			"x-api-key":    token,
+		},
+	}
+
+	c := new(Client)
+	c.UserService = NewUserService(baseInfo, client)
+	c.SubscriptionService = NewSubscriptionService(baseInfo, client)
+	c.MessageService = NewMessageService(baseInfo, client)
+	return c
+}
+
+func (c *Client) Host() string {
+	return c.UserService.Host
+}
+
+// AmsRequest contains the necessary data for an ams request to be executed
+type AmsRequest struct {
+	ctx     context.Context
+	method  string
+	url     string
+	body    interface{}
+	headers map[string]string
+	*http.Client
+}
+
+func (a *AmsRequest) execute() (*http.Response, error) {
+
+	req, err := http.NewRequestWithContext(a.ctx, a.method, a.url, a.marshalRequestBody())
+	if err != nil {
+		return &http.Response{}, err
+	}
+
+	// headers
+	for k, v := range a.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := a.Client.Do(req)
+	if err != nil {
+		return &http.Response{}, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		buf := bytes.Buffer{}
+		_, _ = buf.ReadFrom(resp.Body)
+		_ = resp.Body.Close()
+		return &http.Response{}, errors.New(buf.String())
+	}
+
+	return resp, nil
+}
+
+func (a *AmsRequest) marshalRequestBody() io.Reader {
+	if a.body == nil {
+		return nil
+	}
+	b, _ := json.Marshal(a.body)
+	return bytes.NewReader(b)
+}

--- a/pkg/ams/v1/client_test.go
+++ b/pkg/ams/v1/client_test.go
@@ -1,0 +1,182 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type ClientTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ClientTestSuite) TestNewAmsClient() {
+	client := new(http.Client)
+	amsClient := NewClient("https", "localhost", "token", 443, client)
+
+	suite.NotNil(amsClient.UserService)
+	suite.NotNil(amsClient.SubscriptionService)
+
+	// check the proper initialization of the user service
+	suite.NotNil(amsClient.UserService.client)
+	suite.Equal("https", amsClient.UserService.Scheme)
+	suite.Equal("localhost:443", amsClient.UserService.Host)
+	suite.Equal(map[string]string{
+		"Content-type": "application/json",
+		"x-api-key":    "token",
+	}, amsClient.UserService.Headers)
+
+	// check the proper initialization of the subscription service
+	suite.NotNil(amsClient.SubscriptionService.client)
+	suite.Equal("https", amsClient.SubscriptionService.Scheme)
+	suite.Equal("localhost:443", amsClient.SubscriptionService.Host)
+	suite.Equal(map[string]string{
+		"Content-type": "application/json",
+		"x-api-key":    "token",
+	}, amsClient.SubscriptionService.Headers)
+
+	// check the proper initialization of the message service
+	suite.NotNil(amsClient.MessageService.client)
+	suite.Equal("https", amsClient.MessageService.Scheme)
+	suite.Equal("localhost:443", amsClient.MessageService.Host)
+	suite.Equal(map[string]string{
+		"Content-type": "application/json",
+		"x-api-key":    "token",
+	}, amsClient.MessageService.Headers)
+}
+
+func (suite *ClientTestSuite) TestHost() {
+	amsClient := NewClient("https", "localhost", "token", 443, new(http.Client))
+	suite.Equal("localhost:443", amsClient.Host())
+}
+
+func (suite *ClientTestSuite) TestAmsRequestExecute() {
+
+	mrt := new(mockRoundTripper)
+
+	client := &http.Client{
+		Transport: mrt,
+	}
+
+	rBody := mockStruct{
+		FieldOne: "one",
+		FieldTwo: 22,
+	}
+
+	amsRequest := AmsRequest{
+		ctx:    context.Background(),
+		method: http.MethodGet,
+		url:    "https://localhost:443/api",
+		body:   rBody,
+		headers: map[string]string{
+			"Content-type": "application/json",
+			"x-api-key":    "token",
+		},
+		Client: client,
+	}
+
+	amsRequest100 := AmsRequest{
+		ctx:    context.Background(),
+		method: http.MethodGet,
+		url:    "https://localhost:443/api-100",
+		body:   rBody,
+		headers: map[string]string{
+			"Content-type": "application/json",
+			"x-api-key":    "token",
+		},
+		Client: client,
+	}
+
+	amsRequest300 := AmsRequest{
+		ctx:    context.Background(),
+		method: http.MethodGet,
+		url:    "https://localhost:443/api-300",
+		body:   rBody,
+		headers: map[string]string{
+			"Content-type": "application/json",
+			"x-api-key":    "token",
+		},
+		Client: client,
+	}
+
+	// check successful response and execution
+	resp, err := amsRequest.execute()
+	suite.NotNil(resp)
+	suite.Nil(err)
+	// check that the body has been marshaled properly and headers assigned properly
+	b, _ := json.Marshal(rBody)
+	suite.Equal(b, mrt.requestBody)
+	suite.Equal("token", mrt.header.Get("x-api-key"))
+	suite.Equal("application/json", mrt.header.Get("Content-type"))
+	// status code < 200
+	_, err100 := amsRequest100.execute()
+	suite.Equal("error-100", err100.Error())
+	// status code > 300
+	_, err300 := amsRequest300.execute()
+	suite.Equal("error-300", err300.Error())
+}
+
+func TestClientTestSuite(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	suite.Run(t, new(ClientTestSuite))
+}
+
+type mockRoundTripper struct {
+	requestBody []byte
+	header      http.Header
+}
+
+type mockStruct struct {
+	FieldOne string `json:"field_one"`
+	FieldTwo int    `json:"field_two"`
+}
+
+func (m *mockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	var resp *http.Response
+
+	header := make(http.Header)
+	header.Set("Content-type", "application/json")
+
+	m.requestBody, _ = ioutil.ReadAll(r.Body)
+	m.header = r.Header.Clone()
+
+	switch r.URL.Path {
+
+	case "/api":
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader("text")),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/api-100":
+
+		resp = &http.Response{
+			StatusCode: 100,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader("error-100")),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/api-300":
+
+		resp = &http.Response{
+			StatusCode: 300,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader("error-300")),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+	}
+
+	return resp, nil
+}

--- a/pkg/ams/v1/message.go
+++ b/pkg/ams/v1/message.go
@@ -1,0 +1,154 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const (
+	// requires the full subscription path
+	// .e.g. /projects/project_one/subscriptions/sub_one::pull
+	pullMessagePath = "/v1%s:pull"
+	// requires the full subscription path
+	// .e.g. /projects/project_one/subscriptions/sub_one::acknowledge
+	ackMessagePath = "/v1%s:acknowledge"
+)
+
+// Attributes is key/value pairs of extra data
+type Attributes map[string]string
+
+// PullOptions holds information on how we want to pull messages
+type PullOptions struct {
+	// amount of messages to be pulled at once
+	MaxMessages string `json:"maxMessages"`
+	// whether or not it should wait until it gathers
+	// the requested amount of maxMessages
+	// to be pulled or return with what is available
+	ReturnImmediately string `json:"returnImmediately"`
+}
+
+// Message struct used to hold message information
+type Message struct {
+	// message id
+	ID string `json:"messageId,omitempty"`
+	// used to hold attribute key/value store
+	Attr Attributes `json:"attributes,omitempty"`
+	// base64 encoded data payload
+	Data string `json:"data"`
+	// publish time date of message
+	PubTime string `json:"publishTime,omitempty"`
+}
+
+// ReceivedMessage holds info for a received message
+type ReceivedMessage struct {
+	// id to be used for acknowledgement
+	AckID string `json:"ackId,omitempty"`
+	// the message itself
+	Msg Message `json:"message"`
+}
+
+// ReceivedMessagesList holds the array of the receivedMessages - subscription related
+type ReceivedMessagesList struct {
+	RecMsgs []ReceivedMessage `json:"receivedMessages"`
+}
+
+// IsEmpty returns whether or not a received message list is empty
+func (r *ReceivedMessagesList) IsEmpty() bool {
+	return len(r.RecMsgs) <= 0
+}
+
+// Last returns the last ReceivedMessage of the slice
+func (r *ReceivedMessagesList) Last() ReceivedMessage {
+	return r.RecMsgs[len(r.RecMsgs)-1]
+}
+
+// AckMsgs the ack ids for the messages we want to acknowledge
+type AckMsgs struct {
+	AckIDS []string `json:"ackIds"`
+}
+
+type MessageService struct {
+	client *http.Client
+	AmsBaseInfo
+}
+
+// NewMessageService properly initialises a message service
+func NewMessageService(info AmsBaseInfo, client *http.Client) *MessageService {
+	return &MessageService{
+		AmsBaseInfo: info,
+		client:      client,
+	}
+}
+
+// Pull consumes messages from an subscription.
+// Requires the full subscription path
+// .e.g. /projects/project_one/subscriptions/sub_one
+func (s *MessageService) Pull(ctx context.Context, subscription string, numberOfMessages int64, returnImmediately bool) (ReceivedMessagesList, error) {
+
+	u := url.URL{
+		Host:   s.AmsBaseInfo.Host,
+		Scheme: s.AmsBaseInfo.Scheme,
+		Path:   fmt.Sprintf(pullMessagePath, subscription),
+	}
+
+	req := AmsRequest{
+		ctx:    ctx,
+		method: http.MethodPost,
+		url:    u.String(),
+		body: PullOptions{
+			MaxMessages:       strconv.FormatInt(numberOfMessages, 10),
+			ReturnImmediately: strconv.FormatBool(returnImmediately),
+		},
+		headers: s.AmsBaseInfo.Headers,
+		Client:  s.client,
+	}
+
+	resp, err := req.execute()
+	if err != nil {
+		return ReceivedMessagesList{}, err
+	}
+
+	defer resp.Body.Close()
+
+	reqList := ReceivedMessagesList{}
+	err = json.NewDecoder(resp.Body).Decode(&reqList)
+	if err != nil {
+		return reqList, err
+	}
+
+	return reqList, nil
+}
+
+// Ack acknowledges that an ams message has been consumed and processed
+// Requires the full subscription path
+// .e.g. /projects/project_one/subscriptions/sub_one
+func (s *MessageService) Ack(ctx context.Context, subscription string, ackId string) error {
+
+	u := url.URL{
+		Host:   s.AmsBaseInfo.Host,
+		Scheme: s.AmsBaseInfo.Scheme,
+		Path:   fmt.Sprintf(ackMessagePath, subscription),
+	}
+
+	req := AmsRequest{
+		ctx:     ctx,
+		method:  http.MethodPost,
+		url:     u.String(),
+		body:    AckMsgs{AckIDS: []string{ackId}},
+		headers: s.AmsBaseInfo.Headers,
+		Client:  s.client,
+	}
+
+	resp, err := req.execute()
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/pkg/ams/v1/message_test.go
+++ b/pkg/ams/v1/message_test.go
@@ -1,0 +1,85 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type MessageTestSuite struct {
+	suite.Suite
+}
+
+func (suite *MessageTestSuite) TestNewMessageService() {
+
+	messageService := NewMessageService(AmsBaseInfo{
+		Scheme: "https",
+		Host:   "localhost",
+		Headers: map[string]string{
+			"Content-type": "application/json",
+			"x-api-key":    "token",
+		}}, new(http.Client))
+
+	suite.NotNil(messageService.client)
+	suite.Equal("https", messageService.Scheme)
+	suite.Equal("localhost", messageService.Host)
+	suite.Equal(map[string]string{
+		"Content-type": "application/json",
+		"x-api-key":    "token",
+	}, messageService.Headers)
+}
+
+func (suite *MessageTestSuite) TestPull() {
+
+	mcrt := new(MockConsumeRoundTripper)
+
+	client := &http.Client{
+		Transport: mcrt,
+	}
+
+	amsClient := NewClient("https", "localhost", "token", 443, client)
+
+	m1, e1 := amsClient.Pull(context.Background(), "/normal_sub", 1, true)
+
+	// check pull options(request body)
+	po := PullOptions{}
+	json.Unmarshal(mcrt.RequestBodyBytes, &po)
+
+	suite.Equal("some_data", m1.RecMsgs[0].Msg.Data)
+	suite.Equal("some_id", m1.RecMsgs[0].Msg.ID)
+	suite.Equal("some_ack_id", m1.RecMsgs[0].AckID)
+	suite.Equal("1", po.MaxMessages)
+	suite.Equal("true", po.ReturnImmediately)
+	suite.Nil(e1)
+
+	// check for multiple messages
+	po2 := PullOptions{}
+	mcrt.RequestBodyBytes = []byte{}
+	amsClient.Pull(context.Background(), "/normal_sub", 3, true)
+	json.Unmarshal(mcrt.RequestBodyBytes, &po2)
+	suite.Equal("3", po2.MaxMessages)
+}
+
+func (suite *MessageTestSuite) TestAck() {
+
+	client := &http.Client{
+		Transport: new(MockConsumeRoundTripper),
+	}
+
+	amsClient := NewClient("https", "localhost", "token", 443, client)
+
+	// test the normal case, where the acknowledgement is successful
+
+	e1 := amsClient.Ack(context.Background(), "/normal_sub", "ackid")
+
+	suite.Nil(e1)
+}
+
+func TestMessageTestSuite(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	suite.Run(t, new(MessageTestSuite))
+}

--- a/pkg/ams/v1/mock.go
+++ b/pkg/ams/v1/mock.go
@@ -1,0 +1,325 @@
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type MockAmsRoundTripper struct{}
+
+func (m *MockAmsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	var resp *http.Response
+
+	header := make(http.Header)
+	header.Set("Content-type", "application/json")
+
+	switch r.URL.Path {
+
+	case "/v1/users:byToken/sometoken":
+
+		p1 := Project{
+			Project:       "push1",
+			Subscriptions: []string{"sub1", "errorsub"},
+		}
+
+		p2 := Project{
+			Project:       "push2",
+			Subscriptions: []string{"sub3", "sub4"},
+		}
+
+		userInfo := UserInfo{
+			Name:     "worker",
+			Projects: []Project{p1, p2},
+		}
+
+		b, _ := json.Marshal(userInfo)
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewReader(b)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+	case "/v1/users:byToken/errortoken":
+
+		resp = &http.Response{
+			StatusCode: 500,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader("server internal error")),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+	case "/v1/projects/push1/subscriptions/sub1":
+
+		rp := RetryPolicy{
+			PolicyType: "linear",
+			Period:     300,
+		}
+		authz := AuthorizationHeader{
+			Value: "auth-header-1",
+		}
+
+		pc := PushConfig{
+			Pend:                "example.com:9999",
+			AuthorizationHeader: authz,
+			RetPol:              rp,
+		}
+
+		s := Subscription{
+			FullName:  "/projects/push1/subscriptions/sub1",
+			FullTopic: "/projects/push1/topics/t1",
+			PushCfg:   pc,
+		}
+
+		sb, _ := json.Marshal(s)
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewReader(sb)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/projects/push1/subscriptions/errorsub":
+
+		resp = &http.Response{
+			StatusCode: 500,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader("server internal error")),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/projects/push2/subscriptions/sub3":
+
+		s := Subscription{
+			FullName:  "/projects/push2/subscriptions/sub3",
+			FullTopic: "/projects/push2/topics/t1",
+		}
+
+		sb, _ := json.Marshal(s)
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewReader(sb)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/projects/push2/subscriptions/sub4":
+
+		rp := RetryPolicy{
+			PolicyType: "linear",
+			Period:     300,
+		}
+
+		pc := PushConfig{
+			Pend:   "example.com:9999",
+			RetPol: rp,
+		}
+
+		s := Subscription{
+			FullName:  "/projects/push2/subscriptions/sub4",
+			FullTopic: "/projects/push2/topics/t1",
+			PushCfg:   pc,
+		}
+
+		sb, _ := json.Marshal(s)
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewReader(sb)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	default:
+		resp = &http.Response{
+			StatusCode: 500,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader("unexpected outcome")),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	}
+
+	return resp, nil
+}
+
+type MockConsumeRoundTripper struct {
+	RequestBodyBytes []byte
+}
+
+func (m *MockConsumeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+
+	var resp *http.Response
+
+	header := make(http.Header)
+	header.Set("Content-type", "application/json")
+
+	m.RequestBodyBytes, _ = ioutil.ReadAll(r.Body)
+
+	switch r.URL.Path {
+
+	case "/v1/normal_sub:pull":
+
+		rm := ReceivedMessage{
+			AckID: "some_ack_id",
+			Msg: Message{
+				ID:   "some_id",
+				Data: "some_data",
+			},
+		}
+
+		rml := ReceivedMessagesList{
+			RecMsgs: []ReceivedMessage{rm},
+		}
+
+		b, _ := json.Marshal(rml)
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewReader(b)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/empty_sub:pull":
+
+		rml := ReceivedMessagesList{
+			RecMsgs: make([]ReceivedMessage, 0),
+		}
+
+		b, _ := json.Marshal(rml)
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewReader(b)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/error_sub:pull":
+
+		err := `{
+		 "error": {
+			"code": 500,
+			"message": "Internal error",
+			"status": "INTERNAL_ERROR"
+		 }
+		}`
+
+		resp = &http.Response{
+			StatusCode: 500,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader(err)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/error_sub_no_project:pull":
+
+		err := `{
+		 "error": {
+			"code": 404,
+			"message": "project doesn't exist",
+			"status": "NOT_FOUND"
+		 }
+		}`
+
+		resp = &http.Response{
+			StatusCode: 404,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader(err)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/error_sub_no_sub:pull":
+
+		err := `{
+		 "error": {
+			"code": 404,
+			"message": "Subscription doesn't exist",
+			"status": "NOT_FOUND"
+		 } 
+		}`
+
+		resp = &http.Response{
+			StatusCode: 404,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader(err)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/normal_sub:acknowledge":
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader(`{}`)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/timeout_sub:acknowledge":
+
+		err := `{
+		 "error": {
+			"code": 408,
+			"message": "ack timeout",
+			"status": "TIMEOUT"
+		 }
+		}`
+
+		resp = &http.Response{
+			StatusCode: 408,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader(err)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/normal_sub:modifyPushStatus":
+
+		resp = &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader("")),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	case "/v1/error_sub:modifyPushStatus":
+
+		err := `{
+		 "error": {
+			"code": 500,
+			"message": "Internal error",
+			"status": "INTERNAL_ERROR"
+		 }
+		}`
+
+		resp = &http.Response{
+			StatusCode: 500,
+			// Send response to be tested
+			Body: ioutil.NopCloser(strings.NewReader(err)),
+			// Must be set to non-nil value or it panics
+			Header: header,
+		}
+
+	}
+
+	return resp, nil
+}

--- a/pkg/ams/v1/subscription.go
+++ b/pkg/ams/v1/subscription.go
@@ -1,0 +1,95 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	// requires the full subscription path
+	// .e.g. /projects/project_one/subscriptions/sub_one
+	getSubscriptionPath = "/v1%s"
+)
+
+type Subscription struct {
+	FullName   string     `json:"name"`
+	FullTopic  string     `json:"topic"`
+	PushCfg    PushConfig `json:"pushConfig"`
+	PushStatus string     `json:"push_status"`
+}
+
+// PushConfig holds optional configuration for push operations
+type PushConfig struct {
+	Pend                string              `json:"pushEndpoint"`
+	AuthorizationHeader AuthorizationHeader `json:"authorization_header"`
+	MaxMessages         int64               `json:"maxMessages"`
+	RetPol              RetryPolicy         `json:"retryPolicy"`
+}
+
+// AuthorizationHeader holds an optional value to be supplied as an Authorization header to push requests
+type AuthorizationHeader struct {
+	Value string `json:"value"`
+}
+
+// RetryPolicy holds information on retry policies
+type RetryPolicy struct {
+	PolicyType string `json:"type,omitempty"`
+	Period     uint32 `json:"period,omitempty"`
+}
+
+func (s *Subscription) IsPushEnabled() bool {
+	return s.PushCfg != PushConfig{}
+}
+
+type SubscriptionService struct {
+	client *http.Client
+	AmsBaseInfo
+}
+
+// NewSubscriptionService properly initialises a subscription service
+func NewSubscriptionService(info AmsBaseInfo, client *http.Client) *SubscriptionService {
+	return &SubscriptionService{
+		AmsBaseInfo: info,
+		client:      client,
+	}
+}
+
+// GetSubscription retrieves the respective subscription info.
+// Requires the full subscription path
+// .e.g. /projects/project_one/subscriptions/sub_one
+func (s *SubscriptionService) GetSubscription(ctx context.Context, subscription string) (Subscription, error) {
+
+	u := url.URL{
+		Host:   s.AmsBaseInfo.Host,
+		Scheme: s.AmsBaseInfo.Scheme,
+		Path:   fmt.Sprintf(getSubscriptionPath, subscription),
+	}
+
+	req := AmsRequest{
+		ctx:     ctx,
+		method:  http.MethodGet,
+		url:     u.String(),
+		body:    nil,
+		headers: s.AmsBaseInfo.Headers,
+		Client:  s.client,
+	}
+
+	resp, err := req.execute()
+	if err != nil {
+		return Subscription{}, err
+	}
+
+	defer resp.Body.Close()
+
+	sub := Subscription{}
+
+	err = json.NewDecoder(resp.Body).Decode(&sub)
+	if err != nil {
+		return Subscription{}, err
+	}
+
+	return sub, nil
+}

--- a/pkg/ams/v1/subscription_test.go
+++ b/pkg/ams/v1/subscription_test.go
@@ -1,0 +1,88 @@
+package v1
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type SubscriptionTestSuite struct {
+	suite.Suite
+}
+
+func (suite *SubscriptionTestSuite) TestNewSubscriptionService() {
+
+	subscriptionService := NewSubscriptionService(AmsBaseInfo{
+		Scheme: "https",
+		Host:   "localhost",
+		Headers: map[string]string{
+			"Content-type": "application/json",
+			"x-api-key":    "token",
+		}}, new(http.Client))
+
+	suite.NotNil(subscriptionService.client)
+	suite.Equal("https", subscriptionService.Scheme)
+	suite.Equal("localhost", subscriptionService.Host)
+	suite.Equal(map[string]string{
+		"Content-type": "application/json",
+		"x-api-key":    "token",
+	}, subscriptionService.Headers)
+}
+
+func (suite *SubscriptionTestSuite) TestIsPushEnabled() {
+	sub := Subscription{
+		PushCfg: PushConfig{
+			Pend: "remote.com",
+		},
+	}
+	suite.True(sub.IsPushEnabled())
+
+	sub2 := Subscription{}
+	suite.False(sub2.IsPushEnabled())
+}
+
+func (suite *SubscriptionTestSuite) TestGetSubscription() {
+
+	client := &http.Client{
+		Transport: new(MockAmsRoundTripper),
+	}
+	amsClient := NewClient("", "", "", 443, client)
+
+	rp := RetryPolicy{
+		PolicyType: "linear",
+		Period:     300,
+	}
+
+	authz := AuthorizationHeader{
+		Value: "auth-header-1",
+	}
+
+	pc := PushConfig{
+		Pend:                "example.com:9999",
+		AuthorizationHeader: authz,
+		RetPol:              rp,
+	}
+
+	expectedSub := Subscription{
+		FullName:  "/projects/push1/subscriptions/sub1",
+		FullTopic: "/projects/push1/topics/t1",
+		PushCfg:   pc,
+	}
+
+	sub1, err1 := amsClient.GetSubscription(context.TODO(), "/projects/push1/subscriptions/sub1")
+	suite.Equal(expectedSub, sub1)
+	suite.Nil(err1)
+
+	// error case
+	sub2, err2 := amsClient.GetSubscription(context.TODO(), "/projects/push1/subscriptions/errorsub")
+	suite.Equal(Subscription{}, sub2)
+	suite.Equal("server internal error", err2.Error())
+}
+
+func TestSubscriptionTestSuite(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	suite.Run(t, new(SubscriptionTestSuite))
+}

--- a/pkg/ams/v1/user.go
+++ b/pkg/ams/v1/user.go
@@ -1,0 +1,70 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	getUserByTokenPath = "/v1/users:byToken/%s"
+)
+
+type UserInfo struct {
+	Name     string    `json:"name"`
+	Projects []Project `json:"projects"`
+}
+
+type Project struct {
+	Project       string   `json:"project"`
+	Subscriptions []string `json:"subscriptions"`
+}
+
+type UserService struct {
+	client *http.Client
+	AmsBaseInfo
+}
+
+// NewUserService properly initialises a user service
+func NewUserService(info AmsBaseInfo, client *http.Client) *UserService {
+	return &UserService{
+		AmsBaseInfo: info,
+		client:      client,
+	}
+}
+
+// GetUserByToken uses the provided token to get the respective user profile
+func (us *UserService) GetUserByToken(ctx context.Context, token string) (UserInfo, error) {
+
+	u := url.URL{
+		Host:   us.AmsBaseInfo.Host,
+		Scheme: us.AmsBaseInfo.Scheme,
+		Path:   fmt.Sprintf(getUserByTokenPath, token),
+	}
+
+	req := AmsRequest{
+		ctx:     ctx,
+		method:  http.MethodGet,
+		url:     u.String(),
+		body:    nil,
+		headers: us.AmsBaseInfo.Headers,
+		Client:  us.client,
+	}
+
+	resp, err := req.execute()
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	defer resp.Body.Close()
+
+	userInfo := UserInfo{}
+
+	err = json.NewDecoder(resp.Body).Decode(&userInfo)
+	if err != nil {
+		return UserInfo{}, err
+	}
+	return userInfo, nil
+}

--- a/pkg/ams/v1/user_test.go
+++ b/pkg/ams/v1/user_test.go
@@ -1,0 +1,82 @@
+package v1
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type UserTestSuite struct {
+	suite.Suite
+}
+
+func (suite *UserTestSuite) TestNewUserService() {
+
+	userService := NewUserService(AmsBaseInfo{
+		Scheme: "https",
+		Host:   "localhost",
+		Headers: map[string]string{
+			"Content-type": "application/json",
+			"x-api-key":    "token",
+		}}, new(http.Client))
+
+	suite.NotNil(userService.client)
+	suite.Equal("https", userService.Scheme)
+	suite.Equal("localhost", userService.Host)
+	suite.Equal(map[string]string{
+		"Content-type": "application/json",
+		"x-api-key":    "token",
+	}, userService.Headers)
+}
+
+func (suite *UserTestSuite) TestGetUserByToken() {
+
+	client := &http.Client{
+		Transport: new(MockAmsRoundTripper),
+	}
+
+	userService := UserService{
+		client: client,
+		AmsBaseInfo: AmsBaseInfo{
+			Scheme: "https",
+			Host:   "localhost",
+			Headers: map[string]string{
+				"Content-type": "application/json",
+				"x-api-key":    "sometoken",
+			},
+		},
+	}
+
+	u1, err1 := userService.GetUserByToken(context.TODO(), "sometoken")
+
+	p1 := Project{
+		Project:       "push1",
+		Subscriptions: []string{"sub1", "errorsub"},
+	}
+
+	p2 := Project{
+		Project:       "push2",
+		Subscriptions: []string{"sub3", "sub4"},
+	}
+
+	expectedUserInfo := UserInfo{
+		Name:     "worker",
+		Projects: []Project{p1, p2},
+	}
+
+	suite.Equal(expectedUserInfo, u1)
+	suite.Nil(err1)
+
+	// error case
+	u2, err2 := userService.GetUserByToken(context.TODO(), "errortoken")
+	suite.Equal(UserInfo{}, u2)
+	suite.Equal("server internal error", err2.Error())
+}
+
+func TestUserServiceTestSuite(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	suite.Run(t, new(UserTestSuite))
+}

--- a/push/worker_test.go
+++ b/push/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	amsPb "github.com/ARGOeu/ams-push-server/api/v1/grpc/proto"
 	"github.com/ARGOeu/ams-push-server/consumers"
+	ams "github.com/ARGOeu/ams-push-server/pkg/ams/v1"
 	"github.com/ARGOeu/ams-push-server/retrypolicies"
 	"github.com/ARGOeu/ams-push-server/senders"
 	"github.com/stretchr/testify/suite"
@@ -20,7 +21,7 @@ type WorkerTestSuite struct {
 // TestNew tests that the worker factory behaves properly
 func (suite *WorkerTestSuite) TestNew() {
 
-	c := consumers.NewAmsHttpConsumer("", "", "", &http.Client{})
+	c := consumers.NewAmsHttpConsumer("", &ams.Client{})
 	s := senders.NewHttpSender("", "", &http.Client{})
 	sub := &amsPb.Subscription{
 		PushConfig: &amsPb.PushConfig{

--- a/senders/httpsender.go
+++ b/senders/httpsender.go
@@ -72,7 +72,9 @@ func (s *HttpSender) Send(ctx context.Context, msgs PushMsgs, format pushMessage
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusProcessing {
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusCreated &&
+		resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusProcessing {
 		buf := bytes.Buffer{}
 		buf.ReadFrom(resp.Body)
 		return errors.New(buf.String())

--- a/senders/sender.go
+++ b/senders/sender.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	amsPb "github.com/ARGOeu/ams-push-server/api/v1/grpc/proto"
-	"github.com/ARGOeu/ams-push-server/consumers"
+	ams "github.com/ARGOeu/ams-push-server/pkg/ams/v1"
 	"net/http"
 )
 
@@ -40,7 +40,7 @@ func New(sType senderType, cfg amsPb.PushConfig, client *http.Client) (Sender, e
 // PushMsg holds data to be send to a remote endpoint
 type PushMsg struct {
 	// the actual message
-	Msg consumers.Message `json:"message"`
+	Msg ams.Message `json:"message"`
 	// the source
 	Sub string `json:"subscription"`
 }


### PR DESCRIPTION
adds support for header based authroization through the x-api-key header.

This change exposed an architectural issue where identical code fragments would be all over the place making it harder to maintain and propagate changes.

We group all ams related functionality under a single AmsClient, which itself is comprised by 3 different services, the user service that holds any functionality needed for accessing ams users, the sub service that holds any functionality for accessing subscriptions, and the message service which holds functionality for consuming and acknowledging messages.

This approach also opens up the possibility, to share the ams client as a seperate module if we ever need to use it in multiple go projects.