### PR TITLE
AMS Push Server 1.3.0 release

### DIFF
--- a/ams-push-server.spec
+++ b/ams-push-server.spec
@@ -3,7 +3,7 @@
 
 Name: ams-push-server
 Summary: ARGO Ams Push Server.
-Version: 1.2.0
+Version: 1.3.0
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -56,6 +56,8 @@ go clean
 %attr(0644,root,root) /usr/lib/systemd/system/ams-push-server.service
 
 %changelog
+* Tue Jun 17 2025 Agelos Tsalapatis  <agelos.tsal@gmail.com> 1.3.0-1%{?dist}
+- Release of ams-push-server 1.3.0
 * Fri Jul 29 2022 Agelos Tsalapatis  <agelos.tsal@gmail.com> 1.2.0-1%{?dist}
 - Release of ams-push-server 1.2.0
 * Tue Oct 5 2021 Agelos Tsalapatis  <agelos.tsal@gmail.com> 1.0.1-1%{?dist}


### PR DESCRIPTION
AM-400  ams-push-server: Allow service to bind to configurable ip
AM-344 ams-push-server: Upgrade to go 1.21
